### PR TITLE
Re-install pip in anaconda2 as pip is uninstalled when conda is updated

### DIFF
--- a/local/bin/install_anaconda2.sh
+++ b/local/bin/install_anaconda2.sh
@@ -31,4 +31,5 @@ rm -rf $TMPDIR
 
 source $INSTALL_DIR/.anaconda2/bin/activate
 conda update -n base -y conda
+conda install -n base -y pip  # pip is uninstalled when conda is updated
 source $INSTALL_DIR/.anaconda2/bin/deactivate


### PR DESCRIPTION
I'm not sure why, but currently, `conda update -n base -y conda` in install_anaconda2.sh removes `pip`:
```
$ curl -L https://github.com/wkentaro/dotfiles/raw/master/local/bin/install_anaconda2.sh | bash -s .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   155  100   155    0     0    258      0 --:--:-- --:--:-- --:--:--   257
100   822  100   822    0     0    745      0  0:00:01  0:00:01 --:--:--   745
PREFIX=/home/pazeshun/test_anaconda/.anaconda2
Unpacking payload ...
Collecting package metadata (current_repodata.json): done                                                                            
Solving environment: done

## Package Plan ##

  environment location: /home/pazeshun/test_anaconda/.anaconda2

  added / updated specs:
    - _libgcc_mutex==0.1=main
    - asn1crypto==1.2.0=py27_0
    - ca-certificates==2019.10.16=0
    - certifi==2019.9.11=py27_0
    - cffi==1.13.0=py27h2e261b9_0
    - chardet==3.0.4=py27_1003
    - conda-package-handling==1.6.0=py27h7b6447c_0
    - conda==4.7.12=py27_0
    - cryptography==2.8=py27h1ba5d50_0
    - enum34==1.1.6=py27_1
    - futures==3.3.0=py27_0
    - idna==2.8=py27_0
    - ipaddress==1.0.23=py_0
    - libedit==3.1.20181209=hc058e9b_0
    - libffi==3.2.1=hd88cf55_4
    - libgcc-ng==9.1.0=hdf63c60_0
    - libstdcxx-ng==9.1.0=hdf63c60_0
    - ncurses==6.1=he6710b0_1
    - openssl==1.1.1d=h7b6447c_3
    - pip==19.3.1=py27_0
    - pycosat==0.6.3=py27h14c3975_0
    - pycparser==2.19=py27_0
    - pyopenssl==19.0.0=py27_0
    - pysocks==1.7.1=py27_0
    - python==2.7.17=h9bab390_0
    - readline==7.0=h7b6447c_5
    - requests==2.22.0=py27_0
    - ruamel_yaml==0.15.46=py27h14c3975_0
    - setuptools==41.4.0=py27_0
    - six==1.12.0=py27_0
    - sqlite==3.30.0=h7b6447c_0
    - tk==8.6.8=hbc83047_0
    - tqdm==4.36.1=py_0
    - urllib3==1.24.2=py27_0
    - wheel==0.33.6=py27_0
    - yaml==0.1.7=had09818_2
    - zlib==1.2.11=h7b6447c_3


The following NEW packages will be INSTALLED:

  _libgcc_mutex      pkgs/main/linux-64::_libgcc_mutex-0.1-main
  asn1crypto         pkgs/main/linux-64::asn1crypto-1.2.0-py27_0
  ca-certificates    pkgs/main/linux-64::ca-certificates-2019.10.16-0
  certifi            pkgs/main/linux-64::certifi-2019.9.11-py27_0
  cffi               pkgs/main/linux-64::cffi-1.13.0-py27h2e261b9_0
  chardet            pkgs/main/linux-64::chardet-3.0.4-py27_1003
  conda              pkgs/main/linux-64::conda-4.7.12-py27_0
  conda-package-han~ pkgs/main/linux-64::conda-package-handling-1.6.0-py27h7b6447c_0
  cryptography       pkgs/main/linux-64::cryptography-2.8-py27h1ba5d50_0
  enum34             pkgs/main/linux-64::enum34-1.1.6-py27_1
  futures            pkgs/main/linux-64::futures-3.3.0-py27_0
  idna               pkgs/main/linux-64::idna-2.8-py27_0
  ipaddress          pkgs/main/noarch::ipaddress-1.0.23-py_0
  libedit            pkgs/main/linux-64::libedit-3.1.20181209-hc058e9b_0
  libffi             pkgs/main/linux-64::libffi-3.2.1-hd88cf55_4
  libgcc-ng          pkgs/main/linux-64::libgcc-ng-9.1.0-hdf63c60_0
  libstdcxx-ng       pkgs/main/linux-64::libstdcxx-ng-9.1.0-hdf63c60_0
  ncurses            pkgs/main/linux-64::ncurses-6.1-he6710b0_1
  openssl            pkgs/main/linux-64::openssl-1.1.1d-h7b6447c_3
  pip                pkgs/main/linux-64::pip-19.3.1-py27_0
  pycosat            pkgs/main/linux-64::pycosat-0.6.3-py27h14c3975_0
  pycparser          pkgs/main/linux-64::pycparser-2.19-py27_0
  pyopenssl          pkgs/main/linux-64::pyopenssl-19.0.0-py27_0
  pysocks            pkgs/main/linux-64::pysocks-1.7.1-py27_0
  python             pkgs/main/linux-64::python-2.7.17-h9bab390_0
  readline           pkgs/main/linux-64::readline-7.0-h7b6447c_5
  requests           pkgs/main/linux-64::requests-2.22.0-py27_0
  ruamel_yaml        pkgs/main/linux-64::ruamel_yaml-0.15.46-py27h14c3975_0
  setuptools         pkgs/main/linux-64::setuptools-41.4.0-py27_0
  six                pkgs/main/linux-64::six-1.12.0-py27_0
  sqlite             pkgs/main/linux-64::sqlite-3.30.0-h7b6447c_0
  tk                 pkgs/main/linux-64::tk-8.6.8-hbc83047_0
  tqdm               pkgs/main/noarch::tqdm-4.36.1-py_0
  urllib3            pkgs/main/linux-64::urllib3-1.24.2-py27_0
  wheel              pkgs/main/linux-64::wheel-0.33.6-py27_0
  yaml               pkgs/main/linux-64::yaml-0.1.7-had09818_2
  zlib               pkgs/main/linux-64::zlib-1.2.11-h7b6447c_3


Preparing transaction: done
Executing transaction: done
installation finished.
WARNING:
    You currently have a PYTHONPATH environment variable set. This may cause
    unexpected behavior when running the Python interpreter in Miniconda2.
    For best results, please verify that your PYTHONPATH only points to
    directories of packages that are compatible with the Python interpreter
    in Miniconda2: /home/pazeshun/test_anaconda/.anaconda2
/home/pazeshun/test_anaconda
Collecting package metadata (current_repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: /home/pazeshun/test_anaconda/.anaconda2

  added / updated specs:
    - conda


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    asn1crypto-1.3.0           |           py27_0         164 KB
    ca-certificates-2020.1.1   |                0         125 KB
    certifi-2019.11.28         |           py27_0         153 KB
    cffi-1.14.0                |   py27he30daa8_1         221 KB
    conda-4.8.3                |           py27_0         2.8 MB
    libffi-3.3                 |       he6710b0_1          50 KB
    ncurses-6.2                |       he6710b0_1         817 KB
    openssl-1.1.1g             |       h7b6447c_0         2.5 MB
    pycosat-0.6.3              |   py27h7b6447c_0          81 KB
    pycparser-2.20             |             py_0          92 KB
    pyopenssl-19.1.0           |           py27_0          86 KB
    requests-2.22.0            |           py27_1          92 KB
    ruamel_yaml-0.15.87        |   py27h7b6447c_0         249 KB
    sqlite-3.31.1              |       h62c20be_1         1.1 MB
    tqdm-4.46.0                |             py_0          60 KB
    ------------------------------------------------------------
                                           Total:         8.6 MB

The following packages will be REMOVED:

  pip-19.3.1-py27_0
  wheel-0.33.6-py27_0

The following packages will be UPDATED:

  asn1crypto                                   1.2.0-py27_0 --> 1.3.0-py27_0
  ca-certificates                              2019.10.16-0 --> 2020.1.1-0
  certifi                                  2019.9.11-py27_0 --> 2019.11.28-py27_0
  cffi                                1.13.0-py27h2e261b9_0 --> 1.14.0-py27he30daa8_1
  conda                                       4.7.12-py27_0 --> 4.8.3-py27_0
  libffi                                   3.2.1-hd88cf55_4 --> 3.3-he6710b0_1
  ncurses                                    6.1-he6710b0_1 --> 6.2-he6710b0_1
  openssl                                 1.1.1d-h7b6447c_3 --> 1.1.1g-h7b6447c_0
  pycparser          pkgs/main/linux-64::pycparser-2.19-py~ --> pkgs/main/noarch::pycparser-2.20-py_0
  pyopenssl                                   19.0.0-py27_0 --> 19.1.0-py27_0
  requests                                    2.22.0-py27_0 --> 2.22.0-py27_1
  ruamel_yaml                        0.15.46-py27h14c3975_0 --> 0.15.87-py27h7b6447c_0
  sqlite                                  3.30.0-h7b6447c_0 --> 3.31.1-h62c20be_1
  tqdm                                          4.36.1-py_0 --> 4.46.0-py_0

The following packages will be DOWNGRADED:

  pycosat                              0.6.3-py27h14c3975_0 --> 0.6.3-py27h7b6447c_0



Downloading and Extracting Packages
pyopenssl-19.1.0     | 86 KB     | ########################################################################################## | 100% 
ncurses-6.2          | 817 KB    | ########################################################################################## | 100% 
pycparser-2.20       | 92 KB     | ########################################################################################## | 100% 
requests-2.22.0      | 92 KB     | ########################################################################################## | 100% 
certifi-2019.11.28   | 153 KB    | ########################################################################################## | 100% 
sqlite-3.31.1        | 1.1 MB    | ########################################################################################## | 100% 
tqdm-4.46.0          | 60 KB     | ########################################################################################## | 100% 
cffi-1.14.0          | 221 KB    | ########################################################################################## | 100% 
libffi-3.3           | 50 KB     | ########################################################################################## | 100% 
openssl-1.1.1g       | 2.5 MB    | ########################################################################################## | 100% 
pycosat-0.6.3        | 81 KB     | ########################################################################################## | 100% 
ruamel_yaml-0.15.87  | 249 KB    | ########################################################################################## | 100% 
conda-4.8.3          | 2.8 MB    | ########################################################################################## | 100% 
ca-certificates-2020 | 125 KB    | ########################################################################################## | 100% 
asn1crypto-1.3.0     | 164 KB    | ########################################################################################## | 100% 
Preparing transaction: done
Verifying transaction: done
Executing transaction: done
DeprecationWarning: 'source deactivate' is deprecated. Use 'conda deactivate'.
```
This is fatal at https://github.com/start-jsk/jsk_apc/blob/129f6cc9cbff8739da9118157c215f4a683eb91e/demos/grasp_fusion/.make/install.sh#L36

This PR re-installs `pip` explicitly.