### PR TITLE
docs: add linking-out guidance to the to-html skill

### DIFF
--- a/agents/skills/to-html/FORMAT.md
+++ b/agents/skills/to-html/FORMAT.md
@@ -59,6 +59,23 @@ section, a typical unit is one `<article>`:
 No paragraphs of explanation. If a diagram needs a paragraph to be understood,
 redraw the diagram.
 
+## Linking out
+
+Self-contained means no build step and no bundled assets - it does **not** mean
+no hyperlinks. Default to linking; only skip it when there is genuinely nothing
+to point at.
+
+- **Sources / provenance.** When the content derives from something with an
+  address - a PR or commit, a ticket, a spec - link it so a reader can trace the
+  claim and reproduce the work. A short "Sources" section or footer is the usual
+  home.
+- **Related documents.** If the file lands next to sibling docs (a `tmp/`
+  collection, a published pages dir, a docs folder), link the ones a reader
+  would naturally reach for next, and add a back-link to any index. Glance at the
+  destination directory before assuming there is nothing to link.
+
+Keep this general - plain `<a href>`, not a domain-specific convention.
+
 ## Diagram patterns
 
 Pick what fits. Mix them. Do not make every diagram look the same, variety is

--- a/agents/skills/to-html/SKILL.md
+++ b/agents/skills/to-html/SKILL.md
@@ -47,10 +47,11 @@ Read [FORMAT.md](FORMAT.md) and follow it. The short version:
 
 ### 4. Self-check, then stop
 
-Before handing over, confirm: the file is self-contained (no external resources
-beyond the Tailwind CDN and the Mermaid import), every section carries a visual
-(diagram, comparison, or before/after), and no prose paragraph stands alone
-without a visual or bullets beside it. Fix whatever fails.
+Before handing over, confirm: the file is self-contained (no external scripts or
+assets beyond the Tailwind CDN and the Mermaid import), every section carries a
+visual (diagram, comparison, or before/after), no prose paragraph stands alone
+without a visual or bullets beside it, and it links to its sources and any
+sibling or index docs that exist. Fix whatever fails.
 
 This skill produces the artifact, it does not iterate to perfection on its own.
 If the user wants it polished further, that is a separate pass (e.g. /impeccable).


### PR DESCRIPTION
The skill produced self-contained HTML that read as an island - nothing pointed back at the source it was built from or at neighboring docs. This adds a "Linking out" convention (provenance + related documents) and clarifies that "self-contained" (no build step, no bundled assets) does not mean no hyperlinks.