### PR TITLE
feat(wezterm): cross-platform config themed after Kaku

### DIFF
--- a/config/wezterm/wezterm.lua
+++ b/config/wezterm/wezterm.lua
@@ -1,0 +1,115 @@
+-- WezTerm configured to look and feel like Kaku (a WezTerm fork with clean
+-- macOS defaults). The point is one terminal that looks the same on macOS and
+-- Linux; Kaku is macOS-only, so its bundled defaults are reproduced here.
+
+local wezterm = require 'wezterm'
+
+local config = wezterm.config_builder and wezterm.config_builder() or {}
+
+local is_macos = wezterm.target_triple:find 'darwin' ~= nil
+
+-- ===== Color scheme =====
+-- Matches the Catppuccin Mocha used in ghostty and the personal kaku.lua.
+-- Swap this single line for any built-in scheme (e.g. 'Kaku Dark' is not
+-- bundled, but 'Tokyo Night', 'Dracula', etc. are) to retheme everything.
+config.color_scheme = 'Catppuccin Mocha'
+
+-- Catppuccin Mocha tokens reused for the titlebar so the integrated traffic
+-- lights blend into the terminal background like Kaku's.
+local BASE = '#1e1e2e'
+local SURFACE = '#313244'
+local TEXT = '#cdd6f4'
+local OVERLAY = '#6c7086'
+local FONT_FAMILY = 'JetBrains Mono'
+
+-- ===== Font =====
+-- No font_rules on purpose: Kaku's bundled rules flatten bold/italic/faint
+-- (faint forced to base weight), which kills dimming on e.g. Claude Code's
+-- suggestion text. Relying on the full JetBrains Mono family lets WezTerm
+-- derive real bold/italic and dim faint text natively. Emoji/CJK fallbacks are
+-- per-OS to avoid missing-font warnings on Linux.
+local font_fallback = { { family = FONT_FAMILY } }
+if is_macos then
+  table.insert(font_fallback, { family = 'PingFang SC' })
+  table.insert(font_fallback, 'Apple Color Emoji')
+else
+  table.insert(font_fallback, 'Noto Color Emoji')
+end
+
+config.font = wezterm.font_with_fallback(font_fallback)
+config.font_size = is_macos and 13.0 or 9.0
+config.line_height = 1.28
+config.harfbuzz_features = { 'calt=0', 'clig=0', 'liga=0' }
+config.bold_brightens_ansi_colors = false
+config.use_cap_height_to_scale_fallback_fonts = false
+config.custom_block_glyphs = true
+config.unicode_version = 14
+
+-- ===== Window =====
+config.window_decorations = 'INTEGRATED_BUTTONS|RESIZE'
+config.window_padding = { left = '40px', right = '40px', top = '40px', bottom = '0px' }
+config.initial_cols = 110
+config.initial_rows = 22
+config.use_resize_increments = false
+config.adjust_window_size_when_changing_font_size = false
+config.window_close_confirmation = 'NeverPrompt'
+
+config.window_frame = {
+  font = wezterm.font { family = FONT_FAMILY, weight = 'Regular' },
+  font_size = is_macos and 14.0 or 11.0,
+  active_titlebar_bg = BASE,
+  inactive_titlebar_bg = BASE,
+  active_titlebar_fg = TEXT,
+  inactive_titlebar_fg = OVERLAY,
+}
+
+-- ===== Tab bar =====
+-- Retro (non-fancy) tab bar, hidden entirely with a single tab; this is why
+-- Kaku shows no tab strip most of the time.
+config.tab_bar_at_bottom = false
+config.use_fancy_tab_bar = false
+config.tab_max_width = 32
+config.hide_tab_bar_if_only_one_tab = true
+config.show_tab_index_in_tab_bar = true
+config.show_new_tab_button_in_tab_bar = false
+config.colors = {
+  tab_bar = {
+    background = BASE,
+    active_tab = { bg_color = SURFACE, fg_color = TEXT, intensity = 'Bold' },
+    inactive_tab = { bg_color = BASE, fg_color = OVERLAY },
+    inactive_tab_hover = { bg_color = SURFACE, fg_color = TEXT },
+    new_tab = { bg_color = BASE, fg_color = OVERLAY },
+    new_tab_hover = { bg_color = SURFACE, fg_color = TEXT },
+  },
+}
+
+-- ===== Cursor =====
+config.default_cursor_style = 'BlinkingBar'
+config.cursor_thickness = '2px'
+config.cursor_blink_rate = 500
+config.cursor_blink_ease_in = 'Constant'
+config.cursor_blink_ease_out = 'Constant'
+
+-- ===== Scrollback / selection =====
+config.scrollback_lines = 10000
+config.selection_word_boundary = ' \t\n{}[]()"\'-'
+
+-- ===== Keyboard =====
+-- Negotiate the Kitty keyboard protocol so modified chords (alt+shift+k/j for
+-- herdr workspace nav) arrive unambiguously, then send raw bytes for the chords
+-- herdr expects instead of the protocol's CSI-u encodings. Mirrors kaku.lua.
+config.enable_kitty_keyboard = true
+config.keys = {
+  { key = 'Enter', mods = 'CTRL', action = wezterm.action.SendString '\r' },
+  { key = 'Enter', mods = 'SHIFT', action = wezterm.action.SendString '\n' },
+  { key = '[', mods = 'CTRL', action = wezterm.action.SendString '\x1b' },
+  -- macOS treats Option+N as a dead key; send legacy meta-n so herdr's
+  -- next_tab (alt+n) fires. Harmless on Linux where alt+n already maps here.
+  { key = 'n', mods = 'ALT', action = wezterm.action.SendString '\x1bn' },
+  -- Close tab without the "Really kill this tab?" prompt (herdr manages its
+  -- own panes). Covers the macOS and Linux default close-tab shortcuts.
+  { key = 'w', mods = 'CMD', action = wezterm.action.CloseCurrentTab { confirm = false } },
+  { key = 'w', mods = 'CTRL|SHIFT', action = wezterm.action.CloseCurrentTab { confirm = false } },
+}
+
+return config

--- a/dotfiles.yaml
+++ b/dotfiles.yaml
@@ -8,6 +8,8 @@ config/ghostty/config.linux:
   uname: Linux
 config/kaku/kaku.lua:
   .config/kaku/kaku.lua
+config/wezterm/wezterm.lua:
+  .config/wezterm/wezterm.lua
 config/herdr/config.toml:
   .config/herdr/config.toml
 config/zellij:


### PR DESCRIPTION
## Summary
- Adds `config/wezterm/wezterm.lua`, a cross-platform WezTerm config that reproduces Kaku's clean macOS defaults so the same terminal can be used on macOS and Linux (Kaku is macOS-only).
- Ports the GUI-like polish: `INTEGRATED_BUTTONS` titlebar, retro tab bar hidden when only one tab, 40px padding, BlinkingBar cursor, ligatures off, `line_height 1.28`.
- Color is Catppuccin Mocha (matching ghostty and the personal `kaku.lua`); font size is per-OS (mac 13 / linux 9).
- Carries over `enable_kitty_keyboard` and the `Enter`/`[`/`alt+n` SendString binds herdr relies on, plus `Cmd+W`/`Ctrl+Shift+W` to close a tab without the confirmation prompt.
- Deliberately no `font_rules`: Kaku's bundled rules flatten faint to base weight, which kills dimming on Claude Code suggestion text; the full JetBrains Mono family lets WezTerm dim faint natively.
- Wires the file into `dotfiles.yaml` (`.config/wezterm/wezterm.lua`).

## Test plan
- [x] `wezterm ls-fonts` loads the config cleanly (no `config_builder` validation errors)
- [x] Launched WezTerm on macOS: seamless dark titlebar, no tab strip with one tab, dimmed suggestion text, `Cmd+W` closes without prompt
