### PR TITLE
chore: remove stale install-manifest references to deleted configs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "emacs.d/packages/platform-p"]
-	path = emacs.d/packages/platform-p
-	url = https://github.com/ongaeshi/platform-p
 [submodule "tmux/plugins/tpm"]
 	path = tmux/plugins/tpm
 	url = https://github.com/tmux-plugins/tpm.git

--- a/dotfiles.yaml
+++ b/dotfiles.yaml
@@ -20,8 +20,6 @@ config/peco:
   .config/peco
 config/rofi:
   .config/rofi
-config/uv/uv.toml:
-  .config/uv/uv.toml
 gitconfig:
   .gitconfig
 gitmessage.txt:
@@ -56,10 +54,6 @@ tmux:
   .tmux
 tmux.conf:
   .tmux.conf
-vim:
-  .vim
-vimrc:
-  .vimrc
 zsh:
   .zsh
 zshrc:


### PR DESCRIPTION
`dotfiles.yaml` and `.gitmodules` still listed sources that no longer exist in the repo, so every install silently glob-skipped them or carried a vestigial submodule entry. This removes the dead references:

- `dotfiles.yaml`: `config/uv/uv.toml` (file removed in 22e4e0b), `vim` and `vimrc` (migrated to `config/nvim` in 2d83d92).
- `.gitmodules`: the `emacs.d/packages/platform-p` submodule block (`emacs.d` removed in 3deb866; the gitlink is already gone from the tree).

Purely subtractive and behavior-preserving: `install.py` runs `glob.glob()` over each source and the removed entries already matched nothing, and the stale submodule has no gitlink so `git submodule update --init --recursive` already ignored it.

## Test plan
- [x] `dotfiles.yaml` parses and the three removed sources glob to empty; kept sources unaffected
- [x] `git submodule status` unchanged (only `tmux/plugins/tpm`, `zsh/ohmyzsh` remain)
