### PR TITLE
fix(zsh): make compress-pdf usage guard actually return

### DIFF
--- a/zsh/rc/alias.sh
+++ b/zsh/rc/alias.sh
@@ -238,7 +238,8 @@ macclean () {
 
 compress-pdf () {
   if [ ! $# -eq 2 ]; then
-    echo "Usage: compress_pdf INPUT_FILE OUTPUT_FILE"
+    echo "Usage: compress-pdf INPUT_FILE OUTPUT_FILE" >&2
+    return 1
   fi
   local input
   local output


### PR DESCRIPTION
`compress-pdf` printed its usage message on a bad argument count but did not
return, so it fell through and ran `gs` with empty `$1`/`$2`, silently writing a
broken PDF to an empty output path. Add `return 1` so a bad invocation stops at
the guard. While there, send the usage line to stderr (so it doesn't pollute
command substitution) and fix the function name in it (`compress_pdf` ->
`compress-pdf`).

## Test plan
- [x] Sourced the function with a `gs` stub: `compress-pdf onearg` now returns 1, prints usage to stderr, and never invokes `gs`
- [x] `shellcheck` clean on the changed lines
