### PR TITLE
chore(zsh): remove unused compress-pdf alias

### DIFF
--- a/zsh/rc/alias.sh
+++ b/zsh/rc/alias.sh
@@ -236,29 +236,6 @@ macclean () {
   find . -type f -name '.DS_Store' -delete
 }
 
-compress-pdf () {
-  if [ ! $# -eq 2 ]; then
-    echo "Usage: compress_pdf INPUT_FILE OUTPUT_FILE"
-  fi
-  local input
-  local output
-  input=$1
-  output=$2
-    # -dPDFSETTINGS=/default \
-  gs \
-    -sDEVICE=pdfwrite \
-    -dCompatibilityLevel=1.4 \
-    -dPDFSETTINGS=/prepress \
-    -dNOPAUSE \
-    -dQUIET \
-    -dBATCH \
-    -dDetectDuplicateImages \
-    -dCompressFonts=true \
-    -r300 \
-    -sOutputFile=${output} \
-    ${input}
-}
-
 cmake-prefix.. () {
   if [ $# != 1 ]; then
     return 1


### PR DESCRIPTION
The `compress-pdf` alias is no longer used, so removing it. This supersedes #22, which fixed the alias's usage guard.

## Test plan
- [x] `grep` confirms no remaining references to `compress-pdf` in the repo