### PR TITLE
fix(tmux): guard copy-mode Enter xclip binding with Linux

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -126,7 +126,7 @@ if-shell "uname | grep -q Linux" 'bind-key -T copy-mode-vi y send-keys -X copy-p
 # # Update default binding of `Enter` to also use copy-pipe
 unbind -T copy-mode-vi Enter
 if-shell "uname | grep -q Darwin" 'bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"'
-if-shell "uname | grep -q Darwin" 'bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "xclip -in -selection clipboard"'
+if-shell "uname | grep -q Linux" 'bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "xclip -in -selection clipboard"'
 
 # reattach on OS X
 if-shell "uname | grep -q Darwin" 'set -g default-command "reattach-to-user-namespace -l zsh"'


### PR DESCRIPTION
The second copy-mode `Enter` binding was guarded with `Darwin` instead of `Linux`, duplicating the line above it. On macOS the `xclip` binding (a Linux-only tool) overwrote the `pbcopy` binding, so pressing Enter in copy mode silently failed to copy; on Linux `Enter` was never bound at all. Guarding it with `Linux` makes `Enter` mirror the existing per-platform `y` binding (`pbcopy` on macOS, `xclip` on Linux).

## Test plan
- [x] `tmux -f tmux.conf` parses with exit 0 (tmux 3.6b)
- [x] On macOS, `list-keys -T copy-mode-vi` now shows `Enter` → `reattach-to-user-namespace pbcopy`, matching `y` (previously `xclip`)
