### PR TITLE
build: migrate install to Makefile + uv

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,6 @@ jobs:
       run: |
         git submodule update --init --recursive
 
-    - name: Install system requirements
-      run: |
-        sudo apt-get install -qq -y python3-setuptools python3-pip python3-yaml
-
     - name: Install this project
       run: |
-        python3 install.py
+        make install

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+SHELL := bash
+
+.PHONY: help install install-private dry-run uv
+.DEFAULT_GOAL := help
+
+install install-private dry-run: export PATH := $(HOME)/.local/bin:$(PATH)
+
+help:
+	@printf '\033[1;32mAvailable targets:\033[0m\n'
+	@grep -E '^[a-zA-Z_-]+:.*# ' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*# "} {printf "  \033[1;36m%-20s\033[0m %s\n", $$1, $$2}'
+
+install: uv  # Install dotfiles and commands
+	uv run install.py
+
+install-private: uv  # Install dotfiles including the private repo
+	uv run install.py --private
+
+dry-run: uv  # Print install commands without executing them
+	uv run install.py --dry-run
+
+uv:
+	@hash uv 2>/dev/null || bash scripts/install_uv.sh

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 ```bash
 INSTALL_DIR=$HOME/.dotfiles  # you can change this location
 git clone --recursive https://github.com/wkentaro/dotfiles.git $INSTALL_DIR && cd $INSTALL_DIR
-./install.py
+make install
 ```
 
 

--- a/install.py
+++ b/install.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
-
-from __future__ import print_function
+# /// script
+# requires-python = ">=3.8"
+# dependencies = ["pyyaml"]
+# ///
 
 import argparse
 import glob
@@ -8,13 +10,8 @@ import os
 import os.path as osp
 import platform
 import subprocess
-import sys
 
-try:
-    import yaml
-except ImportError:
-    print("Please install PyYAML: pip install --user PyYAML", file=sys.stderr)
-    quit(1)
+import yaml
 
 
 UNAME = platform.platform().split("-")[0]


### PR DESCRIPTION
## Summary
- Add a `Makefile` as the install entry point (`make install`); a bare `make` prints a colorized help listing parsed from target comments.
- `install.py` declares its `pyyaml` dependency via PEP 723 inline metadata, so `uv run install.py` provisions it; the manual `pip install PyYAML` fallback (and the Python 2 `print_function` shim) are removed.
- The `help` target is parsed with `grep`/`awk`, so it needs neither Python nor uv and works on a fresh machine; `PATH` is scoped to the install targets so a freshly-bootstrapped uv is found.
- CI installs via `make install` instead of `apt-get` system packages plus `python3 install.py`.

## Test plan
- [x] `make help` and bare `make` list targets in a stripped env (`env -i PATH=/usr/bin:/bin`), with no uv or Python available
- [x] `make dry-run` runs `install.py --dry-run` through uv (PyYAML provisioned by the inline metadata)
- [x] `uvx ruff check install.py` passes
