### PR TITLE
chore(zsh): remove dead 'gap' variable assignment in git.sh

### DIFF
--- a/zsh/plugins/git.sh
+++ b/zsh/plugins/git.sh
@@ -244,7 +244,6 @@ alias gsuir='gsui --recursive'
 #   compdef _git git_checkout_by_fzy=git-checkout 2>/dev/null
 # fi
 #
-gap='git add -p'
 
 alias gl="git log --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%ad) %C(bold blue)<%an>%Creset' --abbrev-commit --date=iso"
 alias glg="gl --graph"


### PR DESCRIPTION
`zsh/plugins/git.sh` had `gap='git add -p'` without the `alias` keyword, so it only set an unused shell variable (`$gap` is read nowhere) and defined no command. Because it was broken it was never used as `git add -p`, and oh-my-zsh (sourced earlier in `zshrc`) already binds `gap='git apply'` and `gapa='git add --patch'`. Removing the dead line leaves `gap` resolving to oh-my-zsh's `git apply` with no behavior change.

## Test plan
- [x] `zsh -n zsh/plugins/git.sh` parses clean
- [x] `zsh -i -c 'alias gap'` → `gap='git apply'` (unchanged before/after)

Closes #28
