### PR TITLE
chore: use ask exemplar for short writing

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -28,7 +28,7 @@
 - When you commit code, use the git-hunk CLI to split into logical commits. Run `git-hunk skills get core` first to learn its usage.
 - When you access a website, use the agent-browser CLI to navigate and extract information. Run `agent-browser skills get core --full` first to learn its usage.
 - When you make a pr, use /make-pr.
-- When you draft a tweet/aphorism (or any short, voice-driven line), run /exemplar-review against the relevant exemplar (Naval-style for aphorisms) after generating candidates. It scores each line against a rubric of observable criteria (first-read parse, compression, clean antithesis, universal-not-paraphrase) and reliably reorders your confidence ranking. Worked well for selecting the strongest of 10 drafts.
+- When you draft a tweet/aphorism (or any short, voice-driven line), run /ask-exemplar as an Evaluation against the relevant Exemplar (Naval-style for aphorisms) after generating candidates. It scores each line against a rubric of observable criteria (first-read parse, compression, clean antithesis, universal-not-paraphrase) and reliably reorders your confidence ranking. Worked well for selecting the strongest of 10 drafts.
 
 ## Workflow
 


### PR DESCRIPTION
> *This was generated by AI.*

Keeps the personal short-writing workflow valid after [wkentaro/skills#7](https://github.com/wkentaro/skills/pull/7) replaces `exemplar-review` with the unified `ask-exemplar` Evaluation.

## Test plan
- [x] `git diff --check`
- [x] Verified that `agents/AGENTS.md` has no `exemplar-review` reference
