### PR TITLE
feat: improve yabai window controls

### DIFF
--- a/config/karabiner/karabiner.json
+++ b/config/karabiner/karabiner.json
@@ -14,7 +14,7 @@
                                 },
                                 "to": [
                                     {
-                                        "shell_command": "/usr/bin/pgrep -x yabai >/dev/null && /opt/homebrew/bin/yabai --stop-service || /opt/homebrew/bin/yabai --start-service"
+                                        "shell_command": "if /usr/bin/pgrep -x yabai >/dev/null; then /opt/homebrew/bin/yabai --stop-service && $HOME/.local/bin/set-yabai-border-color; else /opt/homebrew/bin/yabai --start-service; fi"
                                     }
                                 ],
                                 "type": "basic"

--- a/config/skhd/skhdrc
+++ b/config/skhd/skhdrc
@@ -7,7 +7,7 @@ cmd + shift - b      : space=$(yabai -m query --windows --window 2>/dev/null | j
 # Return to BSP and rotate its tree through four orientations.
 cmd + ctrl - j : yabai -m query --spaces --space | jq -e '.type == "bsp"' >/dev/null || yabai -m space --layout bsp; yabai -m space --rotate 270
 cmd + ctrl - l : yabai -m space --layout "$(yabai -m query --spaces --space | jq -r 'if .type == "stack" then "bsp" else "stack" end')"
-cmd + ctrl - t : yabai -m window --toggle float
+cmd + ctrl - t : yabai -m window --toggle float && "$HOME/.local/bin/set-yabai-border-color"
 cmd + ctrl - f : yabai -m window --toggle zoom-fullscreen
 cmd + ctrl - b : yabai -m space --balance
 

--- a/config/skhd/skhdrc
+++ b/config/skhd/skhdrc
@@ -3,6 +3,7 @@
 cmd + shift - return : open -na WezTerm
 # Launch in the background so macOS cannot switch to the browser's existing Space.
 cmd + shift - b      : space=$(yabai -m query --windows --window 2>/dev/null | jq -er .space) || space=$(yabai -m query --spaces --space | jq -r .index); label=open-brave-here-$$; if yabai -m rule --add --one-shot label="$label" app="^Brave Browser$" space="$space" && open -gna "Brave Browser" --args --new-window; then tries=0; while yabai -m rule --list | jq -e --arg label "$label" '.[] | select(.label == $label)' >/dev/null && [ "$tries" -lt 100 ]; do sleep 0.05; tries=$((tries + 1)); done; yabai -m rule --remove "$label" 2>/dev/null || yabai -m window --focus "$(yabai -m query --spaces --space "$space" | jq -r '."last-window"')"; fi
+cmd + shift - x : open -na X
 
 # Return to BSP and rotate its tree through four orientations.
 cmd + ctrl - j : yabai -m query --spaces --space | jq -e '.type == "bsp"' >/dev/null || yabai -m space --layout bsp; yabai -m space --rotate 270

--- a/config/yabai/yabairc
+++ b/config/yabai/yabairc
@@ -14,4 +14,5 @@ yabai -m config \
     mouse_follows_focus off \
     focus_follows_mouse off
 
-borders active_color=0xff737373 inactive_color=0x00000000 width=8.0 &
+"$HOME/.local/bin/set-yabai-border-color"
+yabai -m signal --add event=window_focused action="$HOME/.local/bin/set-yabai-border-color"

--- a/local/bin/set-yabai-border-color
+++ b/local/bin/set-yabai-border-color
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+color=$(
+    /opt/homebrew/bin/yabai -m query --windows --window 2>/dev/null |
+        /opt/homebrew/bin/jq -er 'if ."is-floating" then "0xff0a84ff" else "0xff737373" end'
+) || color=0xff0a84ff
+
+/opt/homebrew/bin/borders active_color="$color" inactive_color=0x00000000 width=8.0 &


### PR DESCRIPTION
Floating windows were visually indistinguishable from tiled windows because the border stayed gray. The focused border now turns macOS blue when a window is floating or yabai is disabled.

Also includes the requested `Cmd-Shift-X` launcher for the X app.

Validation: ShellCheck and shell syntax passed for the helper and yabairc; the Karabiner JSON and both border-state mappings were verified.
