### PR TITLE
fix: skip unavailable agent CLIs

### DIFF
--- a/scripts/install_agents_config.sh
+++ b/scripts/install_agents_config.sh
@@ -22,11 +22,15 @@ _install_attention_span() (
 )
 
 _install_ponytail() {
-  claude plugin marketplace add "DietrichGebert/ponytail"
-  claude plugin install "ponytail@ponytail" --scope user --yes
+  if command -v claude >/dev/null; then
+    claude plugin marketplace add "DietrichGebert/ponytail"
+    claude plugin install "ponytail@ponytail" --scope user --yes
+  fi
 
-  codex plugin marketplace add "DietrichGebert/ponytail"
-  codex plugin add "ponytail@ponytail"
+  if command -v codex >/dev/null; then
+    codex plugin marketplace add "DietrichGebert/ponytail"
+    codex plugin add "ponytail@ponytail"
+  fi
 }
 
 main() {


### PR DESCRIPTION
Restores CI after Ponytail plugin installation made the personal installer require Claude and Codex, neither of which exists on GitHub's Ubuntu runner.

The installer skips only unavailable client-specific plugin commands; the shared skills installation still runs for both agent configuration directories.

Validation: missing-CLI reproduction and ShellCheck.
